### PR TITLE
fix: use the patched version of pytest-regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "pytest-cov",
     "pytest-deadfixtures",
     "httplib2",
-    "pytest-regressions @ git+https://github.com/12rambau/pytest-regressions@isinstance"
+    "pytest-regressions>=2.4.3", # https://github.com/ESSS/pytest-regressions/issues/136
 ]
 doc = [
     "sphinx>=6.2.1,<7", # https://github.com/pydata/pydata-sphinx-theme/issues/1404


### PR DESCRIPTION
The dataframe_regression needed a patch to work with inherited classes. 
To publish on pipy I needed to wait that my patch was published by ESSS